### PR TITLE
[I-5]logging 통합 필요

### DIFF
--- a/configs/logging.json
+++ b/configs/logging.json
@@ -6,6 +6,9 @@
     },
     "payload_format": {
       "format": "%(asctime)s:\n%(message)s"
+    },
+    "plain": {
+      "format": "%(message)s"
     }
   },
   "handlers": {
@@ -20,19 +23,31 @@
       "filename": "log/payload.log",
       "level": "INFO",
       "formatter": "payload_format"
+    },
+    "werkzeug": {
+      "class": "logging.FileHandler",
+      "filename": "log/werkzeug.log",
+      "level": "INFO",
+      "formatter": "plain"
     }
   },
   "loggers": {
+    "flask.app": {
+      "level": "INFO",
+      "handlers": [
+        "file"
+      ]
+    },
     "payload_logger": {
       "level": "INFO",
       "handlers": [
         "payload_file"
       ]
     },
-    "logger": {
+    "werkzeug": {
       "level": "INFO",
       "handlers": [
-        "file"
+        "werkzeug"
       ]
     }
   }

--- a/init.py
+++ b/init.py
@@ -5,5 +5,5 @@ with open('configs/logging.json', 'rt') as f:
     logging_config = json.load(f)
 
 logging.config.dictConfig(logging_config)
-logger = logging.getLogger("logger")
+logger = logging.getLogger("flask.app")
 payload_logger = logging.getLogger("payload_logger")


### PR DESCRIPTION
https://github.com/lightjune/jenkins-trigger/issues/5

로그 포맷을 바꿔보려고 했는데, 쉽게 바꿀 수도 없고, 관리하기가 힘든 것 같아, flask 와 werkzeug 의 기본 로거를 그대로 사용한다. 

logging.json 에서 직접 설정하고, logger 에 플라스크 로거를 할당한다.

- ```flask.log```: 플라스크 기본 로깅(예외 스택) + 직접 메시지 넘겨서 찍는 로깅.
- ```werkzeug.log```: werkzeug 가 자체로 찍는 로깅.
- ```payload.log```: HTTP에 실려오는 것 보기 좋게 따로 로깅.
- ```uwsgi.log```: uwsgi 에서 찍는 로깅.
